### PR TITLE
AWS Multi-AZ HA routing and naming fixes.

### DIFF
--- a/aws/6.4/ha/config-active.conf
+++ b/aws/6.4/ha/config-active.conf
@@ -40,7 +40,7 @@ set mtu 9001
 next
 end
 config sys ha
-set group-name Azure-HA
+set group-name AWS-HA
 set priority 255
 set mode a-p
 set hbdev port3 100
@@ -50,6 +50,11 @@ config  ha-mgmt-interfaces
 edit 1
 set interface port4
 set gateway ${mgmt_gateway_ip}
+next
+edit 2
+set interface port3
+set dst ${passive_peerip} 255.255.255.255
+set gateway ${passive_peergwy}
 next
 end
 set override disable

--- a/aws/6.4/ha/config-passive.conf
+++ b/aws/6.4/ha/config-passive.conf
@@ -40,7 +40,7 @@ set mtu 9001
 next
 end
 config sys ha
-set group-name Azure-HA
+set group-name AWS-HA
 set priority 100
 set mode a-p
 set hbdev port3 100
@@ -50,6 +50,11 @@ config  ha-mgmt-interfaces
 edit 1
 set interface port4
 set gateway ${mgmt_gateway_ip}
+next
+edit 2
+set interface port3
+set dst ${active_peerip} 255.255.255.255
+set gateway ${active_peergwy}
 next
 end
 set override disable

--- a/aws/6.4/ha/instance-active.tf
+++ b/aws/6.4/ha/instance-active.tf
@@ -113,6 +113,7 @@ data "template_file" "activeFortiGate" {
     port4_ip        = "${var.activeport4}"
     port4_mask      = "${var.activeport4mask}"
     passive_peerip  = "${var.passiveport3}"
+    passive_peergwy = "${cidrhost(aws_subnet.hasyncsubnetaz1.cidr_block, 1)}"
     mgmt_gateway_ip = "${var.activeport4gateway}"
     defaultgwy      = "${var.activeport1gateway}"
     adminsport      = "${var.adminsport}"

--- a/aws/6.4/ha/instance-passive.tf
+++ b/aws/6.4/ha/instance-passive.tf
@@ -114,6 +114,7 @@ data "template_file" "passiveFortiGate" {
     port4_ip        = "${var.passiveport4}"
     port4_mask      = "${var.passiveport4mask}"
     active_peerip   = "${var.activeport3}"
+    active_peergwy  = "${cidrhost(aws_subnet.hasyncsubnetaz2.cidr_block, 1)}"
     mgmt_gateway_ip = "${var.passiveport4gateway}"
     defaultgwy      = "${var.passiveport1gateway}"
     adminsport      = "${var.adminsport}"


### PR DESCRIPTION
I've had an issue with the HA Sync, as, while the underlying AWS infrastructure knows how to route between HA Sync Networks, there is no corresponding route to the HA opposite via that sync interface.

Also, spotted a typo in the HA group name, which has been fixed.