### PR TITLE
Fix one example to work with macOS on m1

### DIFF
--- a/aws/7.0/transitgwy/terraform/fortigate.tf
+++ b/aws/7.0/transitgwy/terraform/fortigate.tf
@@ -312,11 +312,26 @@ resource "aws_eip" "eip-shared" {
 
 # Create the instances
 resource "aws_instance" "fgt1" {
-  ami                  = var.license_type == "byol" ? var.fgtvmbyolami[var.region] : var.fgt-ond-amis[var.region]
-  instance_type        = var.instance_type
-  availability_zone    = var.availability_zone1
-  key_name             = var.keypair
-  user_data            = data.template_file.fgt_userdata1.rendered
+  ami               = var.license_type == "byol" ? var.fgtvmbyolami[var.region] : var.fgt-ond-amis[var.region]
+  instance_type     = var.instance_type
+  availability_zone = var.availability_zone1
+  key_name          = var.keypair
+  user_data = templatefile("./fgt-userdata.tpl", {
+    fgt_id               = "FGT-Active"
+    type                 = "${var.license_type}"
+    license_file         = "${var.license}"
+    fgt_data_ip          = join("/", [element(tolist(aws_network_interface.eni-fgt1-data.private_ips), 0), cidrnetmask("${var.security_vpc_data_subnet_cidr1}")])
+    fgt_heartbeat_ip     = join("/", [element(tolist(aws_network_interface.eni-fgt1-hb.private_ips), 0), cidrnetmask("${var.security_vpc_heartbeat_subnet_cidr1}")])
+    fgt_mgmt_ip          = join("/", [element(tolist(aws_network_interface.eni-fgt1-mgmt.private_ips), 0), cidrnetmask("${var.security_vpc_mgmt_subnet_cidr1}")])
+    data_gw              = cidrhost(var.security_vpc_data_subnet_cidr1, 1)
+    spoke1_cidr          = var.spoke_vpc1_cidr
+    spoke2_cidr          = var.spoke_vpc2_cidr
+    mgmt_cidr            = var.mgmt_cidr
+    password             = var.password
+    mgmt_gw              = cidrhost(var.security_vpc_mgmt_subnet_cidr1, 1)
+    fgt_priority         = "255"
+    fgt-remote-heartbeat = element(tolist(aws_network_interface.eni-fgt2-hb.private_ips), 0)
+  })
   iam_instance_profile = aws_iam_instance_profile.APICall_profile.name
   network_interface {
     device_index         = 0
@@ -336,11 +351,26 @@ resource "aws_instance" "fgt1" {
 }
 
 resource "aws_instance" "fgt2" {
-  ami                  = var.license_type == "byol" ? var.fgtvmbyolami[var.region] : var.fgt-ond-amis[var.region]
-  instance_type        = var.instance_type
-  availability_zone    = var.availability_zone2
-  key_name             = var.keypair
-  user_data            = data.template_file.fgt_userdata2.rendered
+  ami               = var.license_type == "byol" ? var.fgtvmbyolami[var.region] : var.fgt-ond-amis[var.region]
+  instance_type     = var.instance_type
+  availability_zone = var.availability_zone2
+  key_name          = var.keypair
+  user_data = templatefile("./fgt-userdata.tpl", {
+    fgt_id               = "FGT-Passive"
+    type                 = "${var.license_type}"
+    license_file         = "${var.license2}"
+    fgt_data_ip          = join("/", [element(tolist(aws_network_interface.eni-fgt2-data.private_ips), 0), cidrnetmask("${var.security_vpc_data_subnet_cidr2}")])
+    fgt_heartbeat_ip     = join("/", [element(tolist(aws_network_interface.eni-fgt2-hb.private_ips), 0), cidrnetmask("${var.security_vpc_heartbeat_subnet_cidr2}")])
+    fgt_mgmt_ip          = join("/", [element(tolist(aws_network_interface.eni-fgt2-mgmt.private_ips), 0), cidrnetmask("${var.security_vpc_mgmt_subnet_cidr2}")])
+    data_gw              = cidrhost(var.security_vpc_data_subnet_cidr2, 1)
+    spoke1_cidr          = var.spoke_vpc1_cidr
+    spoke2_cidr          = var.spoke_vpc2_cidr
+    mgmt_cidr            = var.mgmt_cidr
+    password             = var.password
+    mgmt_gw              = cidrhost(var.security_vpc_mgmt_subnet_cidr2, 1)
+    fgt_priority         = "100"
+    fgt-remote-heartbeat = element(tolist(aws_network_interface.eni-fgt1-hb.private_ips), 0)
+  })
   iam_instance_profile = aws_iam_instance_profile.APICall_profile.name
   network_interface {
     device_index         = 0
@@ -356,47 +386,5 @@ resource "aws_instance" "fgt2" {
   }
   tags = {
     Name = "${var.tag_name_prefix}-${var.tag_name_unique}-fgt2"
-  }
-}
-
-data "template_file" "fgt_userdata1" {
-  template = file("./fgt-userdata.tpl")
-
-  vars = {
-    fgt_id               = "FGT-Active"
-    type                 = "${var.license_type}"
-    license_file         = "${var.license}"
-    fgt_data_ip          = join("/", [element(tolist(aws_network_interface.eni-fgt1-data.private_ips), 0), cidrnetmask("${var.security_vpc_data_subnet_cidr1}")])
-    fgt_heartbeat_ip     = join("/", [element(tolist(aws_network_interface.eni-fgt1-hb.private_ips), 0), cidrnetmask("${var.security_vpc_heartbeat_subnet_cidr1}")])
-    fgt_mgmt_ip          = join("/", [element(tolist(aws_network_interface.eni-fgt1-mgmt.private_ips), 0), cidrnetmask("${var.security_vpc_mgmt_subnet_cidr1}")])
-    data_gw              = cidrhost(var.security_vpc_data_subnet_cidr1, 1)
-    spoke1_cidr          = var.spoke_vpc1_cidr
-    spoke2_cidr          = var.spoke_vpc2_cidr
-    mgmt_cidr            = var.mgmt_cidr
-    password             = var.password
-    mgmt_gw              = cidrhost(var.security_vpc_mgmt_subnet_cidr1, 1)
-    fgt_priority         = "255"
-    fgt-remote-heartbeat = element(tolist(aws_network_interface.eni-fgt2-hb.private_ips), 0)
-  }
-}
-
-data "template_file" "fgt_userdata2" {
-  template = file("./fgt-userdata.tpl")
-
-  vars = {
-    fgt_id               = "FGT-Passive"
-    type                 = "${var.license_type}"
-    license_file         = "${var.license2}"
-    fgt_data_ip          = join("/", [element(tolist(aws_network_interface.eni-fgt2-data.private_ips), 0), cidrnetmask("${var.security_vpc_data_subnet_cidr2}")])
-    fgt_heartbeat_ip     = join("/", [element(tolist(aws_network_interface.eni-fgt2-hb.private_ips), 0), cidrnetmask("${var.security_vpc_heartbeat_subnet_cidr2}")])
-    fgt_mgmt_ip          = join("/", [element(tolist(aws_network_interface.eni-fgt2-mgmt.private_ips), 0), cidrnetmask("${var.security_vpc_mgmt_subnet_cidr2}")])
-    data_gw              = cidrhost(var.security_vpc_data_subnet_cidr2, 1)
-    spoke1_cidr          = var.spoke_vpc1_cidr
-    spoke2_cidr          = var.spoke_vpc2_cidr
-    mgmt_cidr            = var.mgmt_cidr
-    password             = var.password
-    mgmt_gw              = cidrhost(var.security_vpc_mgmt_subnet_cidr2, 1)
-    fgt_priority         = "100"
-    fgt-remote-heartbeat = element(tolist(aws_network_interface.eni-fgt1-hb.private_ips), 0)
   }
 }


### PR DESCRIPTION
Terraform provider 'template_file' was deprecated a while ago, and is not available on the macOS m1 platform. the inbuilt templatefile() function does the same thing. There are probably other examples/versions that need this same fix in this repo.