### PR TITLE
update tags, resource group, disk deletion, IP sku

### DIFF
--- a/azure/7.2/ha-port1-mgmt-3ports/README.md
+++ b/azure/7.2/ha-port1-mgmt-3ports/README.md
@@ -1,47 +1,65 @@
 # Deployment of a FortiGate-VM (BYOL/PAYG) Cluster on the Azure with 3 ports
+
 ## Introduction
+
 ## This topology is only recommended for using with FOS 7.0.5 and later.
+
 ## Since it needs FSO 7.0 that supports 3 ports only HA setup
+
 ## port1 - hamgmt/hasync
+
 ## port2 - public/untrust
+
 ## port3 - private/trust
+
 A Terraform script to deploy a FortiGate-VM Cluster on Azure
 
 ## Requirements
+
 * [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) >= 0.12.0
 * Terraform Provider AzureRM >= 2.24.0
 * Terraform Provider Template >= 2.2.0
 * Terraform Provider Random >= 3.1.0
 
-
 ## Deployment overview
+
 Terraform deploys the following components:
-   - Azure Virtual Network with 3 subnets
-   - Two FortiGate-VM (BYOL/PAYG) instances with three NICs.
-   - Two firewall rules.
-   - A Ubuntu Client instance.
+
+* Azure Virtual Network with 3 subnets
+* Two FortiGate-VM (BYOL/PAYG) instances with three NICs.
+* Two firewall rules.
+* A Ubuntu Client instance.
 
 ## Deployment
+
 To deploy the FortiGate-VM to Azure:
+
 1. Clone the repository.
 2. Customize variables in the `terraform.tfvars.example` and `variables.tf` file as needed.  And rename `terraform.tfvars.example` to `terraform.tfvars`.
 3. Initialize the providers and modules:
+
    ```sh
-   $ cd XXXXX
-   $ terraform init
+   cd XXXXX
+   terraform init
     ```
+
 4. Submit the Terraform plan:
+
    ```sh
-   $ terraform plan
+   terraform plan
    ```
+
 5. Verify output.
 6. Confirm and apply the plan:
+
    ```sh
-   $ terraform apply
+   terraform apply
    ```
+
 7. If output is satisfactory, type `yes`.
 
 Output will include the information necessary to log in to the FortiGate-VM instances:
+
 ```sh
 Outputs:
 
@@ -54,16 +72,19 @@ Username = <FGT admin>
 ```
 
 ## Destroy the instance
+
 To destroy the instance, use the command:
+
 ```sh
-$ terraform destroy
+terraform destroy
 ```
 
-# Support
+## Support
+
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
 For direct issues, please refer to the [Issues](https://github.com/fortinet/fortigate-terraform-deploy/issues) tab of this GitHub project.
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
-[License](https://github.com/fortinet/fortigate-terraform-deploy/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.
 
+[License](https://github.com/fortinet/fortigate-terraform-deploy/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.

--- a/azure/7.2/ha-port1-mgmt-3ports/active.tf
+++ b/azure/7.2/ha-port1-mgmt-3ports/active.tf
@@ -20,6 +20,9 @@ resource "azurerm_virtual_machine" "customactivefgtvm" {
   primary_network_interface_id = azurerm_network_interface.activeport1.id
   vm_size                      = var.size
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     id = var.custom ? element(azurerm_image.custom.*.id, 0) : null
   }
@@ -77,7 +80,7 @@ resource "azurerm_virtual_machine" "customactivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -91,6 +94,9 @@ resource "azurerm_virtual_machine" "activefgtvm" {
   network_interface_ids        = [azurerm_network_interface.activeport1.id, azurerm_network_interface.activeport2.id, azurerm_network_interface.activeport3.id]
   primary_network_interface_id = azurerm_network_interface.activeport1.id
   vm_size                      = var.size
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = var.custom ? null : var.publisher
@@ -160,6 +166,6 @@ resource "azurerm_virtual_machine" "activefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-3ports/client.tf
+++ b/azure/7.2/ha-port1-mgmt-3ports/client.tf
@@ -12,7 +12,7 @@ resource "azurerm_network_interface" "clientinternal" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 

--- a/azure/7.2/ha-port1-mgmt-3ports/config-active.conf
+++ b/azure/7.2/ha-port1-mgmt-3ports/config-active.conf
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0
 
 config system global
-set hostname Azure-HA-Active
+set hostname FGT-AP-SDN-Active
 set admin-sport ${adminsport}
 end
 config system interface

--- a/azure/7.2/ha-port1-mgmt-3ports/config-passive.conf
+++ b/azure/7.2/ha-port1-mgmt-3ports/config-passive.conf
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0
 
 config system global
-set hostname Azure-HA-Passive
+set hostname FGT-AP-SDN-Passive
 set admin-sport ${adminsport}
 end
 config system interface

--- a/azure/7.2/ha-port1-mgmt-3ports/main.tf
+++ b/azure/7.2/ha-port1-mgmt-3ports/main.tf
@@ -1,10 +1,10 @@
 // Resource Group
 
 resource "azurerm_resource_group" "myterraformgroup" {
-  name     = "Terraformdemo"
+  name     = "terraform-ha-ap-fgt-3-port"
   location = var.location
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-3ports/network.tf
+++ b/azure/7.2/ha-port1-mgmt-3ports/network.tf
@@ -7,7 +7,7 @@ resource "azurerm_virtual_network" "fgtvnetwork" {
   resource_group_name = azurerm_resource_group.myterraformgroup.name
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -41,7 +41,7 @@ resource "azurerm_public_ip" "ClusterPublicIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -52,7 +52,7 @@ resource "azurerm_public_ip" "ActiveMGMTIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -63,7 +63,7 @@ resource "azurerm_public_ip" "PassiveMGMTIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -86,7 +86,7 @@ resource "azurerm_network_security_group" "publicnetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -108,7 +108,7 @@ resource "azurerm_network_security_group" "privatenetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -158,7 +158,7 @@ resource "azurerm_network_interface" "activeport1" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -178,7 +178,7 @@ resource "azurerm_network_interface" "activeport2" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -197,7 +197,7 @@ resource "azurerm_network_interface" "activeport3" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -237,7 +237,7 @@ resource "azurerm_network_interface" "passiveport1" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -256,7 +256,7 @@ resource "azurerm_network_interface" "passiveport2" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -275,7 +275,7 @@ resource "azurerm_network_interface" "passiveport3" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 

--- a/azure/7.2/ha-port1-mgmt-3ports/output.tf
+++ b/azure/7.2/ha-port1-mgmt-3ports/output.tf
@@ -7,12 +7,11 @@ output "ClusterPublicIP" {
 }
 
 output "ActiveMGMTPublicIP" {
-  value = azurerm_public_ip.ActiveMGMTIP.ip_address
+  value = format("https://%s:%s", azurerm_public_ip.ActiveMGMTIP.ip_address, var.adminsport)
 }
 
-
 output "PassiveMGMTPublicIP" {
-  value = azurerm_public_ip.PassiveMGMTIP.ip_address
+  value = format("https://%s:%s", azurerm_public_ip.PassiveMGMTIP.ip_address, var.adminsport)
 }
 
 output "Username" {
@@ -22,4 +21,3 @@ output "Username" {
 output "Password" {
   value = var.adminpassword
 }
-

--- a/azure/7.2/ha-port1-mgmt-3ports/passive.tf
+++ b/azure/7.2/ha-port1-mgmt-3ports/passive.tf
@@ -8,6 +8,9 @@ resource "azurerm_virtual_machine" "custompassivefgtvm" {
   primary_network_interface_id = azurerm_network_interface.passiveport1.id
   vm_size                      = var.size
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     id = var.custom ? element(azurerm_image.custom.*.id, 0) : null
   }
@@ -66,7 +69,7 @@ resource "azurerm_virtual_machine" "custompassivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }
 
@@ -80,6 +83,9 @@ resource "azurerm_virtual_machine" "passivefgtvm" {
   network_interface_ids        = [azurerm_network_interface.passiveport1.id, azurerm_network_interface.passiveport2.id, azurerm_network_interface.passiveport3.id]
   primary_network_interface_id = azurerm_network_interface.passiveport1.id
   vm_size                      = var.size
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = var.custom ? null : var.publisher
@@ -148,6 +154,6 @@ resource "azurerm_virtual_machine" "passivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-3ports/storage.tf
+++ b/azure/7.2/ha-port1-mgmt-3ports/storage.tf
@@ -14,6 +14,6 @@ resource "azurerm_storage_account" "fgtstorageaccount" {
   account_tier             = "Standard"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - 3 Ports"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/README.md
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/README.md
@@ -1,47 +1,65 @@
 # Deployment of a FortiGate-VM (BYOL/PAYG) Cluster on the Azure in different zones with 3 ports
+
 ## Introduction
+
 ## This topology is only recommended for using with FOS 7.0.5 and later.
+
 ## Since it needs FOS 7.0 that supports 3 ports only HA setup
+
 ## port1 - hamgmt/hasync
+
 ## port2 - public/untrust
+
 ## port3 - private/trust
+
 A Terraform script to deploy a FortiGate-VM Cluster on Azure
 
 ## Requirements
+
 * [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) >= 0.12.0
 * Terraform Provider AzureRM >= 2.24.0
 * Terraform Provider Template >= 2.2.0
 * Terraform Provider Random >= 3.1.0
 
-
 ## Deployment overview
+
 Terraform deploys the following components:
-   - Azure Virtual Network with 3 subnets
-   - Two FortiGate-VM (BYOL/PAYG) instances with three NICs.  Each FortiGate-VM reside in different zones.
-   - Two firewall rules.
-   - A Ubuntu Client instance.
+
+* Azure Virtual Network with 3 subnets
+* Two FortiGate-VM (BYOL/PAYG) instances with three NICs.  Each FortiGate-VM reside in different zones.
+* Two firewall rules.
+* A Ubuntu Client instance.
 
 ## Deployment
+
 To deploy the FortiGate-VM to Azure:
+
 1. Clone the repository.
 2. Customize variables in the `terraform.tfvars.example` and `variables.tf` file as needed.  And rename `terraform.tfvars.example` to `terraform.tfvars`.
 3. Initialize the providers and modules:
+
    ```sh
-   $ cd XXXXX
-   $ terraform init
+   cd XXXXX
+   terraform init
     ```
+
 4. Submit the Terraform plan:
+
    ```sh
-   $ terraform plan
+   terraform plan
    ```
+
 5. Verify output.
 6. Confirm and apply the plan:
+
    ```sh
-   $ terraform apply
+   terraform apply
    ```
+
 7. If output is satisfactory, type `yes`.
 
 Output will include the information necessary to log in to the FortiGate-VM instances:
+
 ```sh
 Outputs:
 
@@ -54,16 +72,19 @@ Username = <FGT admin>
 ```
 
 ## Destroy the instance
+
 To destroy the instance, use the command:
+
 ```sh
-$ terraform destroy
+terraform destroy
 ```
 
-# Support
+## Support
+
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
 For direct issues, please refer to the [Issues](https://github.com/fortinet/fortigate-terraform-deploy/issues) tab of this GitHub project.
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
-[License](https://github.com/fortinet/fortigate-terraform-deploy/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.
 
+[License](https://github.com/fortinet/fortigate-terraform-deploy/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/active.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/active.tf
@@ -21,6 +21,9 @@ resource "azurerm_virtual_machine" "customactivefgtvm" {
   vm_size                      = var.size
   zones                        = [var.zone1]
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     id = var.custom ? element(azurerm_image.custom.*.id, 0) : null
   }
@@ -78,7 +81,7 @@ resource "azurerm_virtual_machine" "customactivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -93,6 +96,9 @@ resource "azurerm_virtual_machine" "activefgtvm" {
   primary_network_interface_id = azurerm_network_interface.activeport1.id
   vm_size                      = var.size
   zones                        = [var.zone1]
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = var.custom ? null : var.publisher
@@ -162,6 +168,6 @@ resource "azurerm_virtual_machine" "activefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/client.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/client.tf
@@ -12,7 +12,7 @@ resource "azurerm_network_interface" "clientinternal" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/config-active.conf
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/config-active.conf
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0
 
 config system global
-set hostname Azure-HA-Active
+set hostname FGT-AP-SDN-Active
 set admin-sport ${adminsport}
 end
 config system interface
@@ -31,7 +31,6 @@ next
 end
 config sys ha
 set group-name Azure-HA
-set priority 255
 set mode a-p
 set hbdev port1 100
 set session-pickup enable

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/config-passive.conf
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/config-passive.conf
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0
 
 config system global
-set hostname Azure-HA-Passive
+set hostname FGT-AP-SDN-Passive
 set admin-sport ${adminsport}
 end
 config system interface

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/main.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/main.tf
@@ -1,10 +1,10 @@
 // Resource Group
 
 resource "azurerm_resource_group" "myterraformgroup" {
-  name     = "Terraformdemo"
+  name     = "terraform-ha-ap-fgt-crosszone-3-port"
   location = var.location
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/network.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/network.tf
@@ -7,7 +7,7 @@ resource "azurerm_virtual_network" "fgtvnetwork" {
   resource_group_name = azurerm_resource_group.myterraformgroup.name
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -42,7 +42,7 @@ resource "azurerm_public_ip" "ClusterPublicIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -54,7 +54,7 @@ resource "azurerm_public_ip" "ActiveMGMTIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -66,7 +66,7 @@ resource "azurerm_public_ip" "PassiveMGMTIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -89,7 +89,7 @@ resource "azurerm_network_security_group" "publicnetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -111,7 +111,7 @@ resource "azurerm_network_security_group" "privatenetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -161,7 +161,7 @@ resource "azurerm_network_interface" "activeport1" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -181,7 +181,7 @@ resource "azurerm_network_interface" "activeport2" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -200,7 +200,7 @@ resource "azurerm_network_interface" "activeport3" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -240,7 +240,7 @@ resource "azurerm_network_interface" "passiveport1" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -259,7 +259,7 @@ resource "azurerm_network_interface" "passiveport2" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -278,7 +278,7 @@ resource "azurerm_network_interface" "passiveport3" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/output.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/output.tf
@@ -7,12 +7,11 @@ output "ClusterPublicIP" {
 }
 
 output "ActiveMGMTPublicIP" {
-  value = azurerm_public_ip.ActiveMGMTIP.ip_address
+  value = format("https://%s:%s", azurerm_public_ip.ActiveMGMTIP.ip_address, var.adminsport)
 }
 
-
 output "PassiveMGMTPublicIP" {
-  value = azurerm_public_ip.PassiveMGMTIP.ip_address
+  value = format("https://%s:%s", azurerm_public_ip.PassiveMGMTIP.ip_address, var.adminsport)
 }
 
 output "Username" {

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/passive.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/passive.tf
@@ -9,6 +9,9 @@ resource "azurerm_virtual_machine" "custompassivefgtvm" {
   vm_size                      = var.size
   zones                        = [var.zone2]
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     id = var.custom ? element(azurerm_image.custom.*.id, 0) : null
   }
@@ -66,7 +69,7 @@ resource "azurerm_virtual_machine" "custompassivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }
 
@@ -81,6 +84,9 @@ resource "azurerm_virtual_machine" "passivefgtvm" {
   primary_network_interface_id = azurerm_network_interface.passiveport1.id
   vm_size                      = var.size
   zones                        = [var.zone2]
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = var.custom ? null : var.publisher
@@ -149,6 +155,6 @@ resource "azurerm_virtual_machine" "passivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/storage.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/storage.tf
@@ -14,6 +14,6 @@ resource "azurerm_storage_account" "fgtstorageaccount" {
   account_tier             = "Standard"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone 3 Ports"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-crosszone-3ports/terraform.tfvars.example
+++ b/azure/7.2/ha-port1-mgmt-crosszone-3ports/terraform.tfvars.example
@@ -1,5 +1,5 @@
 // Change to your own azure environment
 subscription_id = "<fill your subscription id>"
-client_id       = "<fill your cient id>"
+client_id       = "<fill your client id>"
 client_secret   = "<fill your client secret>"
 tenant_id       = "<fill your tenant id>"

--- a/azure/7.2/ha-port1-mgmt-crosszone/README.md
+++ b/azure/7.2/ha-port1-mgmt-crosszone/README.md
@@ -1,47 +1,66 @@
 # Deployment of a FortiGate-VM (BYOL/PAYG) Cluster on the Azure in different zones
+
 ## Introduction
+
 ## This topology is only recommended for using with FOS 6.4.2 and later.
+
 ## port1 - hamgmt
+
 ## port2 - public/untrust
+
 ## port3 - private/trust
+
 ## port4 - hasync
+
 A Terraform script to deploy a FortiGate-VM Cluster on Azure
 
 ## Requirements
+
 * [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) >= 0.12.0
 * Terraform Provider AzureRM >= 2.24.0
 * Terraform Provider Template >= 2.2.0
 * Terraform Provider Random >= 3.1.0
 
-
 ## Deployment overview
+
 Terraform deploys the following components:
-   - Azure Virtual Network with 4 subnets
-   - Two FortiGate-VM (BYOL/PAYG) instances with four NICs.  Each FortiGate-VM reside in different zones.
-   - Two firewall rules.
-   - A Ubuntu Client instance.
+
+* Azure Virtual Network with 4 subnets
+* Two FortiGate-VM (BYOL/PAYG) instances with four NICs.  Each FortiGate-VM reside in different zones.
+* Two firewall rules.
+*A Ubuntu Client instance.
 
 ## Deployment
+
 To deploy the FortiGate-VM to Azure:
+
 1. Clone the repository.
 2. Customize variables in the `terraform.tfvars.example` and `variables.tf` file as needed.  And rename `terraform.tfvars.example` to `terraform.tfvars`.
+
 3. Initialize the providers and modules:
+
    ```sh
-   $ cd XXXXX
-   $ terraform init
+   cd XXXXX
+   terraform init
     ```
+
 4. Submit the Terraform plan:
+
    ```sh
-   $ terraform plan
+   terraform plan
    ```
+
 5. Verify output.
 6. Confirm and apply the plan:
+
    ```sh
-   $ terraform apply
+   terraform apply
    ```
+
 7. If output is satisfactory, type `yes`.
 
 Output will include the information necessary to log in to the FortiGate-VM instances:
+
 ```sh
 Outputs:
 
@@ -54,16 +73,19 @@ Username = <FGT admin>
 ```
 
 ## Destroy the instance
+
 To destroy the instance, use the command:
+
 ```sh
-$ terraform destroy
+terraform destroy
 ```
 
-# Support
+## Support
+
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
 For direct issues, please refer to the [Issues](https://github.com/fortinet/fortigate-terraform-deploy/issues) tab of this GitHub project.
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
-[License](https://github.com/fortinet/fortigate-terraform-deploy/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.
 
+[License](https://github.com/fortinet/fortigate-terraform-deploy/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.

--- a/azure/7.2/ha-port1-mgmt-crosszone/active.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone/active.tf
@@ -21,6 +21,9 @@ resource "azurerm_virtual_machine" "customactivefgtvm" {
   vm_size                      = var.size
   zones                        = [var.zone1]
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     id = var.custom ? element(azurerm_image.custom.*.id, 0) : null
   }
@@ -80,7 +83,7 @@ resource "azurerm_virtual_machine" "customactivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -95,6 +98,9 @@ resource "azurerm_virtual_machine" "activefgtvm" {
   primary_network_interface_id = azurerm_network_interface.activeport1.id
   vm_size                      = var.size
   zones                        = [var.zone1]
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = var.custom ? null : var.publisher
@@ -166,6 +172,6 @@ resource "azurerm_virtual_machine" "activefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-crosszone/client.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone/client.tf
@@ -12,7 +12,7 @@ resource "azurerm_network_interface" "clientinternal" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 

--- a/azure/7.2/ha-port1-mgmt-crosszone/config-active.conf
+++ b/azure/7.2/ha-port1-mgmt-crosszone/config-active.conf
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0
 
 config system global
-set hostname Azure-HA-Active
+set hostname FGT-AP-SDN-Active
 set admin-sport ${adminsport}
 end
 config system interface

--- a/azure/7.2/ha-port1-mgmt-crosszone/config-passive.conf
+++ b/azure/7.2/ha-port1-mgmt-crosszone/config-passive.conf
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0
 
 config system global
-set hostname Azure-HA-Passive
+set hostname FGT-AP-SDN-Passive
 set admin-sport ${adminsport}
 end
 config system interface

--- a/azure/7.2/ha-port1-mgmt-crosszone/main.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone/main.tf
@@ -1,10 +1,10 @@
 // Resource Group
 
 resource "azurerm_resource_group" "myterraformgroup" {
-  name     = "Terraformdemo"
+  name     = "terraform-ha-ap-fgt-crosszone"
   location = var.location
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-crosszone/network.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone/network.tf
@@ -7,7 +7,7 @@ resource "azurerm_virtual_network" "fgtvnetwork" {
   resource_group_name = azurerm_resource_group.myterraformgroup.name
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -49,7 +49,7 @@ resource "azurerm_public_ip" "ClusterPublicIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -61,7 +61,7 @@ resource "azurerm_public_ip" "ActiveMGMTIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -73,7 +73,7 @@ resource "azurerm_public_ip" "PassiveMGMTIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -96,7 +96,7 @@ resource "azurerm_network_security_group" "publicnetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -118,7 +118,7 @@ resource "azurerm_network_security_group" "privatenetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -167,7 +167,7 @@ resource "azurerm_network_interface" "activeport1" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -186,7 +186,7 @@ resource "azurerm_network_interface" "activeport2" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -204,7 +204,7 @@ resource "azurerm_network_interface" "activeport3" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -221,7 +221,7 @@ resource "azurerm_network_interface" "activeport4" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -266,7 +266,7 @@ resource "azurerm_network_interface" "passiveport1" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -284,7 +284,7 @@ resource "azurerm_network_interface" "passiveport2" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -302,7 +302,7 @@ resource "azurerm_network_interface" "passiveport3" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -319,7 +319,7 @@ resource "azurerm_network_interface" "passiveport4" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 

--- a/azure/7.2/ha-port1-mgmt-crosszone/output.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone/output.tf
@@ -7,12 +7,11 @@ output "ClusterPublicIP" {
 }
 
 output "ActiveMGMTPublicIP" {
-  value = azurerm_public_ip.ActiveMGMTIP.ip_address
+  value = format("https://%s:%s", azurerm_public_ip.ActiveMGMTIP.ip_address, var.adminsport)
 }
 
-
 output "PassiveMGMTPublicIP" {
-  value = azurerm_public_ip.PassiveMGMTIP.ip_address
+  value = format("https://%s:%s", azurerm_public_ip.PassiveMGMTIP.ip_address, var.adminsport)
 }
 
 output "Username" {

--- a/azure/7.2/ha-port1-mgmt-crosszone/passive.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone/passive.tf
@@ -9,6 +9,9 @@ resource "azurerm_virtual_machine" "custompassivefgtvm" {
   vm_size                      = var.size
   zones                        = [var.zone2]
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     id = var.custom ? element(azurerm_image.custom.*.id, 0) : null
   }
@@ -68,7 +71,7 @@ resource "azurerm_virtual_machine" "custompassivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }
 
@@ -83,6 +86,9 @@ resource "azurerm_virtual_machine" "passivefgtvm" {
   primary_network_interface_id = azurerm_network_interface.passiveport1.id
   vm_size                      = var.size
   zones                        = [var.zone2]
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = var.custom ? null : var.publisher
@@ -153,6 +159,6 @@ resource "azurerm_virtual_machine" "passivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }

--- a/azure/7.2/ha-port1-mgmt-crosszone/storage.tf
+++ b/azure/7.2/ha-port1-mgmt-crosszone/storage.tf
@@ -14,6 +14,6 @@ resource "azurerm_storage_account" "fgtstorageaccount" {
   account_tier             = "Standard"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Crosszone"
   }
 }

--- a/azure/7.2/ha-port1-mgmt/README.md
+++ b/azure/7.2/ha-port1-mgmt/README.md
@@ -1,47 +1,65 @@
 # Deployment of a FortiGate-VM (BYOL/PAYG) Cluster on the Azure
+
 ## Introduction
+
 ## This topology is only recommended for using with FOS 6.4.2 and later.
+
 ## port1 - hamgmt
+
 ## port2 - public/untrust
+
 ## port3 - private/trust
+
 ## port4 - hasync
+
 A Terraform script to deploy a FortiGate-VM Cluster on Azure
 
 ## Requirements
+
 * [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) >= 0.12.0
 * Terraform Provider AzureRM >= 2.24.0
 * Terraform Provider Template >= 2.2.0
 * Terraform Provider Random >= 3.1.0
 
-
 ## Deployment overview
+
 Terraform deploys the following components:
-   - Azure Virtual Network with 4 subnets
-   - Two FortiGate-VM (BYOL/PAYG) instances with four NICs.
-   - Two firewall rules.
-   - A Ubuntu Client instance.
+
+* Azure Virtual Network with 4 subnets
+* Two FortiGate-VM (BYOL/PAYG) instances with four NICs.
+* Two firewall rules.
+* A Ubuntu Client instance.
 
 ## Deployment
+
 To deploy the FortiGate-VM to Azure:
+
 1. Clone the repository.
 2. Customize variables in the `terraform.tfvars.example` and `variables.tf` file as needed.  And rename `terraform.tfvars.example` to `terraform.tfvars`.
 3. Initialize the providers and modules:
+
    ```sh
-   $ cd XXXXX
-   $ terraform init
-    ```
-4. Submit the Terraform plan:
-   ```sh
-   $ terraform plan
+   cd XXXXX
+   terraform init
    ```
+
+4. Submit the Terraform plan:
+
+   ```sh
+   terraform plan
+   ```
+
 5. Verify output.
 6. Confirm and apply the plan:
+
    ```sh
-   $ terraform apply
+   terraform apply
    ```
+
 7. If output is satisfactory, type `yes`.
 
 Output will include the information necessary to log in to the FortiGate-VM instances:
+
 ```sh
 Outputs:
 
@@ -54,16 +72,19 @@ Username = <FGT admin>
 ```
 
 ## Destroy the instance
+
 To destroy the instance, use the command:
+
 ```sh
-$ terraform destroy
+terraform destroy
 ```
 
-# Support
+## Support
+
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
 For direct issues, please refer to the [Issues](https://github.com/fortinet/fortigate-terraform-deploy/issues) tab of this GitHub project.
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
-[License](https://github.com/fortinet/fortigate-terraform-deploy/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.
 
+[License](https://github.com/fortinet/fortigate-terraform-deploy/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.

--- a/azure/7.2/ha-port1-mgmt/active.tf
+++ b/azure/7.2/ha-port1-mgmt/active.tf
@@ -20,6 +20,9 @@ resource "azurerm_virtual_machine" "customactivefgtvm" {
   primary_network_interface_id = azurerm_network_interface.activeport1.id
   vm_size                      = var.size
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     id = var.custom ? element(azurerm_image.custom.*.id, 0) : null
   }
@@ -80,7 +83,7 @@ resource "azurerm_virtual_machine" "customactivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -94,6 +97,9 @@ resource "azurerm_virtual_machine" "activefgtvm" {
   network_interface_ids        = [azurerm_network_interface.activeport1.id, azurerm_network_interface.activeport2.id, azurerm_network_interface.activeport3.id, azurerm_network_interface.activeport4.id]
   primary_network_interface_id = azurerm_network_interface.activeport1.id
   vm_size                      = var.size
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = var.custom ? null : var.publisher
@@ -165,6 +171,6 @@ resource "azurerm_virtual_machine" "activefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }

--- a/azure/7.2/ha-port1-mgmt/client.tf
+++ b/azure/7.2/ha-port1-mgmt/client.tf
@@ -12,7 +12,7 @@ resource "azurerm_network_interface" "clientinternal" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 

--- a/azure/7.2/ha-port1-mgmt/config-active.conf
+++ b/azure/7.2/ha-port1-mgmt/config-active.conf
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0
 
 config system global
-set hostname Azure-HA-Active
+set hostname FGT-AP-SDN-Active
 set admin-sport ${adminsport}
 end
 config system interface

--- a/azure/7.2/ha-port1-mgmt/config-passive.conf
+++ b/azure/7.2/ha-port1-mgmt/config-passive.conf
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0
 
 config system global
-set hostname Azure-HA-Passive
+set hostname FGT-AP-SDN-Passive
 set admin-sport ${adminsport}
 end
 config system interface

--- a/azure/7.2/ha-port1-mgmt/main.tf
+++ b/azure/7.2/ha-port1-mgmt/main.tf
@@ -1,10 +1,10 @@
 // Resource Group
 
 resource "azurerm_resource_group" "myterraformgroup" {
-  name     = "terraformRSG"
+  name     = "terraform-ha-ap-fgt-port1-mgmt"
   location = var.location
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }

--- a/azure/7.2/ha-port1-mgmt/network.tf
+++ b/azure/7.2/ha-port1-mgmt/network.tf
@@ -7,7 +7,7 @@ resource "azurerm_virtual_network" "fgtvnetwork" {
   resource_group_name = azurerm_resource_group.myterraformgroup.name
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -48,7 +48,7 @@ resource "azurerm_public_ip" "ClusterPublicIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -59,7 +59,7 @@ resource "azurerm_public_ip" "ActiveMGMTIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -70,7 +70,7 @@ resource "azurerm_public_ip" "PassiveMGMTIP" {
   allocation_method   = "Static"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -93,7 +93,7 @@ resource "azurerm_network_security_group" "publicnetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -115,7 +115,7 @@ resource "azurerm_network_security_group" "privatenetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -164,7 +164,7 @@ resource "azurerm_network_interface" "activeport1" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -183,7 +183,7 @@ resource "azurerm_network_interface" "activeport2" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -201,7 +201,7 @@ resource "azurerm_network_interface" "activeport3" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -218,7 +218,7 @@ resource "azurerm_network_interface" "activeport4" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -263,7 +263,7 @@ resource "azurerm_network_interface" "passiveport1" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -281,7 +281,7 @@ resource "azurerm_network_interface" "passiveport2" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -299,7 +299,7 @@ resource "azurerm_network_interface" "passiveport3" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -316,7 +316,7 @@ resource "azurerm_network_interface" "passiveport4" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 

--- a/azure/7.2/ha-port1-mgmt/output.tf
+++ b/azure/7.2/ha-port1-mgmt/output.tf
@@ -7,12 +7,11 @@ output "ClusterPublicIP" {
 }
 
 output "ActiveMGMTPublicIP" {
-  value = azurerm_public_ip.ActiveMGMTIP.ip_address
+  value = format("https://%s:%s", azurerm_public_ip.ActiveMGMTIP.ip_address, var.adminsport)
 }
 
-
 output "PassiveMGMTPublicIP" {
-  value = azurerm_public_ip.PassiveMGMTIP.ip_address
+  value = format("https://%s:%s", azurerm_public_ip.PassiveMGMTIP.ip_address, var.adminsport)
 }
 
 output "Username" {

--- a/azure/7.2/ha-port1-mgmt/passive.tf
+++ b/azure/7.2/ha-port1-mgmt/passive.tf
@@ -8,6 +8,9 @@ resource "azurerm_virtual_machine" "custompassivefgtvm" {
   primary_network_interface_id = azurerm_network_interface.passiveport1.id
   vm_size                      = var.size
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     id = var.custom ? element(azurerm_image.custom.*.id, 0) : null
   }
@@ -67,7 +70,7 @@ resource "azurerm_virtual_machine" "custompassivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }
 
@@ -81,6 +84,9 @@ resource "azurerm_virtual_machine" "passivefgtvm" {
   network_interface_ids        = [azurerm_network_interface.passiveport1.id, azurerm_network_interface.passiveport2.id, azurerm_network_interface.passiveport3.id, azurerm_network_interface.passiveport4.id]
   primary_network_interface_id = azurerm_network_interface.passiveport1.id
   vm_size                      = var.size
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = var.custom ? null : var.publisher
@@ -152,6 +158,6 @@ resource "azurerm_virtual_machine" "passivefgtvm" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }

--- a/azure/7.2/ha-port1-mgmt/storage.tf
+++ b/azure/7.2/ha-port1-mgmt/storage.tf
@@ -14,6 +14,6 @@ resource "azurerm_storage_account" "fgtstorageaccount" {
   account_tier             = "Standard"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform HA AP SDN FortiGates - Port1 Mgmt"
   }
 }

--- a/azure/7.2/ha-port1-mgmt/terraform.tfvars.example
+++ b/azure/7.2/ha-port1-mgmt/terraform.tfvars.example
@@ -1,5 +1,5 @@
 // Change to your own azure environment
 subscription_id = "<fill your subscription id>"
-client_id       = "<fill your cient id>"
+client_id       = "<fill your client id>"
 client_secret   = "<fill your client secret>"
 tenant_id       = "<fill your tenant id>"

--- a/azure/7.2/ha-port1-mgmt/variables.tf
+++ b/azure/7.2/ha-port1-mgmt/variables.tf
@@ -1,8 +1,8 @@
 // Azure configuration
-variable subscription_id {}
-variable client_id {}
-variable client_secret {}
-variable tenant_id {}
+variable "subscription_id" {}
+variable "client_id" {}
+variable "client_secret" {}
+variable "tenant_id" {}
 
 
 //  For HA, choose instance size that support 4 nics at least
@@ -58,7 +58,7 @@ variable "fgtoffer" {
 // BYOL sku: fortinet_fg-vm
 // PAYG sku: fortinet_fg-vm_payg_2022
 variable "fgtsku" {
-  type = map
+  type = map(any)
   default = {
     byol = "fortinet_fg-vm"
     payg = "fortinet_fg-vm_payg_2022"

--- a/azure/7.2/single/README.md
+++ b/azure/7.2/single/README.md
@@ -1,41 +1,54 @@
 # Deployment of a FortiGate-VM(BYOL/PAYG)  on the Azure
+
 ## Introduction
+
 A Terraform script to deploy a FortiGate-VM(BYOL/PAYG) on Azure
 
 ## Requirements
+
 * [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) >= 0.12.0
 * Terraform Provider AzureRM >= 2.38.0
 * Terraform Provider Template >= 2.2.2
 * Terraform Provider Random >= 3.0.0
 
-
 ## Deployment overview
+
 Terraform deploys the following components:
-   - Azure Virtual Network with 2 subnets
-   - One FortiGate-VM instances with 2 NICs
-   - Two firewall rules: one for external, one for internal.
+
+* Azure Virtual Network with 2 subnets
+* One FortiGate-VM instances with 2 NICs
+* Two firewall rules: one for external, one for internal.
 
 ## Deployment
+
 To deploy the FortiGate-VM to Azure:
+
 1. Clone the repository.
 2. Customize variables in the `terraform.tfvars.example` and `variables.tf` file as needed.  And rename `terraform.tfvars.example` to `terraform.tfvars`.
 3. Initialize the providers and modules:
+
    ```sh
-   $ cd XXXXX
-   $ terraform init
+   cd XXXXX
+   terraform init
     ```
+
 4. Submit the Terraform plan:
+
    ```sh
-   $ terraform plan
+   terraform plan
    ```
+
 5. Verify output.
 6. Confirm and apply the plan:
+
    ```sh
-   $ terraform apply
+   terraform apply
    ```
+
 7. If output is satisfactory, type `yes`.
 
 Output will include the information necessary to log in to the FortiGate-VM instances:
+
 ```sh
 FGTPublicIP = <FGT Public IP>
 Password = <FGT Password>
@@ -44,18 +57,19 @@ Username = <FGT Username>
 ```
 
 ## Destroy the instance
+
 To destroy the instance, use the command:
+
 ```sh
-$ terraform destroy
+terraform destroy
 ```
 
-# Support
+## Support
+
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
 For direct issues, please refer to the [Issues](https://github.com/fortinet/fortigate-terraform-deploy/issues) tab of this GitHub project.
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
+
 [License](https://github.com/fortinet/fortigate-terraform-deploy/blob/master/LICENSE) © Fortinet Technologies. All rights reserved.
-
-
-

--- a/azure/7.2/single/fgtvm.tf
+++ b/azure/7.2/single/fgtvm.tf
@@ -20,6 +20,8 @@ resource "azurerm_virtual_machine" "customfgtvm" {
   primary_network_interface_id = azurerm_network_interface.fgtport1.id
   vm_size                      = var.size
 
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     id = var.custom ? element(azurerm_image.custom.*.id, 0) : null
@@ -75,6 +77,10 @@ resource "azurerm_virtual_machine" "fgtvm" {
   network_interface_ids        = [azurerm_network_interface.fgtport1.id, azurerm_network_interface.fgtport2.id]
   primary_network_interface_id = azurerm_network_interface.fgtport1.id
   vm_size                      = var.size
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
   storage_image_reference {
     publisher = var.publisher
     offer     = var.fgtoffer

--- a/azure/7.2/single/main.tf
+++ b/azure/7.2/single/main.tf
@@ -1,10 +1,10 @@
 // Resource Group
 
 resource "azurerm_resource_group" "myterraformgroup" {
-  name     = "terraformRSG"
+  name     = "terraform-single-fgt"
   location = var.location
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform Single FortiGate"
   }
 }

--- a/azure/7.2/single/network.tf
+++ b/azure/7.2/single/network.tf
@@ -7,7 +7,7 @@ resource "azurerm_virtual_network" "fgtvnetwork" {
   resource_group_name = azurerm_resource_group.myterraformgroup.name
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform Single FortiGate"
   }
 }
 
@@ -32,9 +32,10 @@ resource "azurerm_public_ip" "FGTPublicIp" {
   location            = var.location
   resource_group_name = azurerm_resource_group.myterraformgroup.name
   allocation_method   = "Static"
+  sku                 = "Standard"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform Single FortiGate"
   }
 }
 
@@ -57,7 +58,7 @@ resource "azurerm_network_security_group" "publicnetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform Single FortiGate"
   }
 }
 
@@ -79,7 +80,7 @@ resource "azurerm_network_security_group" "privatenetworknsg" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform Single FortiGate"
   }
 }
 
@@ -126,7 +127,7 @@ resource "azurerm_network_interface" "fgtport1" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform Single FortiGate"
   }
 }
 
@@ -143,7 +144,7 @@ resource "azurerm_network_interface" "fgtport2" {
   }
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform Single FortiGate"
   }
 }
 # Connect the security group to the network interfaces

--- a/azure/7.2/single/output.tf
+++ b/azure/7.2/single/output.tf
@@ -3,8 +3,7 @@ output "ResourceGroup" {
 }
 
 output "FGTPublicIP" {
-  value = azurerm_public_ip.FGTPublicIp.ip_address
-
+  value = format("https://%s", azurerm_public_ip.FGTPublicIp.ip_address)
 }
 
 output "Username" {

--- a/azure/7.2/single/storage.tf
+++ b/azure/7.2/single/storage.tf
@@ -14,6 +14,6 @@ resource "azurerm_storage_account" "fgtstorageaccount" {
   account_tier             = "Standard"
 
   tags = {
-    environment = "Terraform Demo"
+    environment = "Terraform Single FortiGate"
   }
 }


### PR DESCRIPTION
Made several updates to each of the 7.2 deployment options.

- main.tf - Resource Group Name reflects the type of FGT deployment
- Any .tf that has a tags block - *environment* tag reflects the name of the deployment
- active.tf and.tf passive modules - added vm disk deletion attributes to custom and standard FortiGate resources. Ensure all components and Resource Group removed on "terraform destroy"
- README.md - correct linting issues
- output.tf - add formatting to Mgmt IP address to include adminsport where appropriate
- updated Public IP Sku to Standard 

These 7.x modules may be used in the new NS7 training materials.