### PR TITLE
fix preemptible instances to false

### DIFF
--- a/gcp/6.2/ha/main.tf
+++ b/gcp/6.2/ha/main.tf
@@ -261,7 +261,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -309,7 +309,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/6.2/single/main.tf
+++ b/gcp/6.2/single/main.tf
@@ -127,7 +127,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-ro", "storage-ro"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/6.4/ha/main.tf
+++ b/gcp/6.4/ha/main.tf
@@ -273,7 +273,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -322,7 +322,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/6.4/single/main.tf
+++ b/gcp/6.4/single/main.tf
@@ -130,7 +130,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-ro", "storage-ro"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.0/ha-3ports/main.tf
+++ b/gcp/7.0/ha-3ports/main.tf
@@ -218,7 +218,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -278,7 +278,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.0/ha-cross-zone-3ports/main.tf
+++ b/gcp/7.0/ha-cross-zone-3ports/main.tf
@@ -220,7 +220,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -283,7 +283,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.0/ha-cross-zone/main.tf
+++ b/gcp/7.0/ha-cross-zone/main.tf
@@ -244,7 +244,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -308,7 +308,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.0/ha-loadbalancer/main.tf
+++ b/gcp/7.0/ha-loadbalancer/main.tf
@@ -247,7 +247,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -314,7 +314,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.0/ha/main.tf
+++ b/gcp/7.0/ha/main.tf
@@ -244,7 +244,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -308,7 +308,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.0/single/main.tf
+++ b/gcp/7.0/single/main.tf
@@ -130,7 +130,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-ro", "storage-ro"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.2/ha-3ports/main.tf
+++ b/gcp/7.2/ha-3ports/main.tf
@@ -218,7 +218,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -278,7 +278,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.2/ha-cross-zone-3-ports/main.tf
+++ b/gcp/7.2/ha-cross-zone-3-ports/main.tf
@@ -220,7 +220,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -283,7 +283,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.2/ha-cross-zone/main.tf
+++ b/gcp/7.2/ha-cross-zone/main.tf
@@ -244,7 +244,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -308,7 +308,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.2/ha-loadbalancer/main.tf
+++ b/gcp/7.2/ha-loadbalancer/main.tf
@@ -247,7 +247,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -314,7 +314,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.2/ha/main.tf
+++ b/gcp/7.2/ha/main.tf
@@ -244,7 +244,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }
@@ -308,7 +308,7 @@ resource "google_compute_instance" "default2" {
     scopes = ["userinfo-email", "compute-rw", "storage-ro", "cloud-platform"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }

--- a/gcp/7.2/single/main.tf
+++ b/gcp/7.2/single/main.tf
@@ -130,7 +130,7 @@ resource "google_compute_instance" "default" {
     scopes = ["userinfo-email", "compute-ro", "storage-ro"]
   }
   scheduling {
-    preemptible       = true
+    preemptible       = false
     automatic_restart = false
   }
 }


### PR DESCRIPTION
Change GCP instances so they are not using preemptible scheduling:


  scheduling {
    preemptible       = false
    automatic_restart = false
  }
}

Info on  preemptible instances:

https://cloud.google.com/compute/docs/instances/preemptible

We probably don't want to use these in general for FortiGates since they will turn off when CPU is low.


