### PR TITLE
📝 fix: comment syntax for 'FortiGate Image name'

### DIFF
--- a/gcp/7.4/ha-cross-zone-3-ports/vars.tf
+++ b/gcp/7.4/ha-cross-zone-3-ports/vars.tf
@@ -27,7 +27,7 @@ variable "token" {
   type    = string
   default = "<gcp oauth access token>"
 }
- FortiGate Image name
+# FortiGate Image name
 # 7.4.1 x86 payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-741-20230905-001-w-license
 # 7.4.1 x86 byol is projects/fortigcp-project-001/global/images/fortinet-fgt-741-20230905-001-w-license
 # 7.4.1 arm payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-arm64-741-20230905-001-w-license

--- a/gcp/7.4/ha-cross-zone/vars.tf
+++ b/gcp/7.4/ha-cross-zone/vars.tf
@@ -27,7 +27,7 @@ variable "token" {
   type    = string
   default = "<gcp oauth access token>"
 }
- FortiGate Image name
+# FortiGate Image name
 # 7.4.1 x86 payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-741-20230905-001-w-license
 # 7.4.1 x86 byol is projects/fortigcp-project-001/global/images/fortinet-fgt-741-20230905-001-w-license
 # 7.4.1 arm payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-arm64-741-20230905-001-w-license

--- a/gcp/7.4/ha-dualloadbalancer/vars.tf
+++ b/gcp/7.4/ha-dualloadbalancer/vars.tf
@@ -23,7 +23,7 @@ variable "token" {
   type    = string
   default = "<gcp oauth access token>"
 }
- FortiGate Image name
+# FortiGate Image name
 # 7.4.1 x86 payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-741-20230905-001-w-license
 # 7.4.1 x86 byol is projects/fortigcp-project-001/global/images/fortinet-fgt-741-20230905-001-w-license
 # 7.4.1 arm payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-arm64-741-20230905-001-w-license

--- a/gcp/7.4/ha-loadbalancer/vars.tf
+++ b/gcp/7.4/ha-loadbalancer/vars.tf
@@ -23,7 +23,7 @@ variable "token" {
   type    = string
   default = "<gcp oauth access token>"
 }
- FortiGate Image name
+# FortiGate Image name
 # 7.4.1 x86 payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-741-20230905-001-w-license
 # 7.4.1 x86 byol is projects/fortigcp-project-001/global/images/fortinet-fgt-741-20230905-001-w-license
 # 7.4.1 arm payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-arm64-741-20230905-001-w-license

--- a/gcp/7.4/ha/vars.tf
+++ b/gcp/7.4/ha/vars.tf
@@ -23,7 +23,7 @@ variable "token" {
   type    = string
   default = "<gcp oauth access token>"
 }
- FortiGate Image name
+# FortiGate Image name
 # 7.4.1 x86 payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-741-20230905-001-w-license
 # 7.4.1 x86 byol is projects/fortigcp-project-001/global/images/fortinet-fgt-741-20230905-001-w-license
 # 7.4.1 arm payg is projects/fortigcp-project-001/global/images/fortinet-fgtondemand-arm64-741-20230905-001-w-license


### PR DESCRIPTION
String literal in terraform files is missing a # hashmark
- fix #197