### PR TITLE
📝 docs(variables.tf): fix comment syntax from single slash to double …

### DIFF
--- a/aws/6.2/ha-single-az/variables.tf
+++ b/aws/6.2/ha-single-az/variables.tf
@@ -10,7 +10,7 @@ variable "az" {
   default = "us-west-2a"
 }
 
-/ IAM role that has proper permission for HA
+// IAM role that has proper permission for HA
 // Refer to the URL For details. https://docs.fortinet.com/document/fortigate-public-cloud/6.2.0/aws-administration-guide/229470/deploying-fortigate-vm-active-passive-ha-aws-between-multiple-zones
 variable "iam" {
   default = "<AWS IAM ROLE NAME>"    //Put in the IAM Role name created

--- a/aws/6.2/ha/variables.tf
+++ b/aws/6.2/ha/variables.tf
@@ -15,7 +15,7 @@ variable "az2" {
   default = "us-west-2b"
 }
 
-/ IAM role that has proper permission for HA
+// IAM role that has proper permission for HA
 // Refer to the URL For details. https://docs.fortinet.com/document/fortigate-public-cloud/6.2.0/aws-administration-guide/229470/deploying-fortigate-vm-active-passive-ha-aws-between-multiple-zones
 variable "iam" {
   default = "<AWS IAM ROLE NAME>"    //Put in the IAM Role name created

--- a/aws/6.2/loadbalancer/variables.tf
+++ b/aws/6.2/loadbalancer/variables.tf
@@ -10,7 +10,7 @@ variable "az" {
   default = "us-west-2a"
 }
 
-/ IAM role that has proper permission for HA
+// IAM role that has proper permission for HA
 // Refer to the URL For details. https://docs.fortinet.com/document/fortigate-public-cloud/6.2.0/aws-administration-guide/229470/deploying-fortigate-vm-active-passive-ha-aws-between-multiple-zones
 variable "iam" {
   default = "<AWS IAM ROLE NAME>"    //Put in the IAM Role name created


### PR DESCRIPTION
- fix #196  
fix comment syntax from single slash to double slash for proper documentation in AWS Terraform files.
 
 The following files have syntax errors, with a single slash instead of the required double slash.
  aws/6.2/ha-single-az/variables.tf
  aws/6.2/ha/variables.tf
  aws/6.2/loadbalancer/variables.tf